### PR TITLE
Add GitHub action to build with `make oss` (2nd)

### DIFF
--- a/.github/workflows/edenscm-oss.yml
+++ b/.github/workflows/edenscm-oss.yml
@@ -1,0 +1,35 @@
+name: Eden SCM OSS
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  make-oss:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Homebrew
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+          echo "HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew" >> $GITHUB_ENV
+          echo "HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar" >> $GITHUB_ENV
+          echo "HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew" >> $GITHUB_ENV
+
+      - name: Install fbthrift (thrift1)
+        run: |
+          brew install fbthrift
+
+      - name: Run make oss
+        working-directory: eden/scm
+        run: make oss
+
+      - name: Show Sapling version
+        working-directory: eden/scm
+        run: ./sl --version

--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -40,6 +40,9 @@ RUST_FLAG = --debug
 endif
 
 $(eval HGROOT := $(shell pwd))
+# Set THRIFT_INCLUDE_PATH to repo root for thrift compiler to find includes
+# like thrift/annotation/cpp.thrift. Only set if not already defined.
+export THRIFT_INCLUDE_PATH ?= $(HGROOT)/../..
 HGPYTHONS ?= $(HGROOT)/build/pythons
 PURE=
 PYFILES:=$(shell find mercurial ext -name '*.py' 2>/dev/null)

--- a/eden/scm/contrib/pick_python.py
+++ b/eden/scm/contrib/pick_python.py
@@ -38,7 +38,6 @@ def main(args):
         + [
             p + EXE
             for p in [
-                "python3.12",
                 "python3.11",
                 "python3.10",
                 "python3.9",


### PR DESCRIPTION
* Installing fbthrift via Homebrew
* Remove support for python3.12, to avoid the error:
  ```
  Traceback (most recent call last):
    File "/Users/rcollins/github/sl/3rd-party/3rd-attempt/sapling/eden/scm/setup.py", line 81, in <module>
      from distutils.ccompiler import new_compiler
  ModuleNotFoundError: No module named 'distutils'
  ```
* Add dependency on `anyhow`, to avoid the error:
  ```
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `anyhow`
    --> saplingnative/bindings/modules/pyedenfsassertedstates/src/dummy_fb.rs:15:36
     |
  15 |     pub fn new(_path: &PathBuf) -> anyhow::Result<Self> {
     |                                    ^^^^^^ use of unresolved module or unlinked crate `anyhow`
     |
     = help: if you wanted to use a crate named `anyhow`, use `cargo add anyhow` to add it to your `Cargo.toml`
  
  error[E0433]: failed to resolve: use of unresolved module or unlinked crate `anyhow`
    --> saplingnative/bindings/modules/pyedenfsassertedstates/src/dummy_fb.rs:25:10
     |
  25 |     ) -> anyhow::Result<ContentLockGuard> {
     |          ^^^^^^ use of unresolved module or unlinked crate `anyhow`
     |
     = help: if you wanted to use a crate named `anyhow`, use `cargo add anyhow` to add it to your `Cargo.toml`
  
  For more information about this error, try `rustc --explain E0433`.
  error: could not compile `pyedenfsassertedstates` (lib) due to 2 previous errors
  ```
* Setting `THRIFT_INCLUDE_PATH` to repo root to avoid the error:
  ```
  error: failed to run custom build command for `fb303_core v0.0.0 (https://github.com/facebook/fb303.git?branch=main#f8745c15)`
  
    --- stderr
  
    thread 'main' panicked at /Users/rcollins/.cargo/git/checkouts/fb303-bf38226a6f1fe012/f8745c1/fb303/thrift/rust/thrift_build.rs:27:10:
    Failed while running thrift compilation: Command 'Command {
        program: "/opt/homebrew/Cellar/fbthrift/2025.09.15.00/bin/thrift1",
        args: [
            "/opt/homebrew/Cellar/fbthrift/2025.09.15.00/bin/thrift1",
            "--gen",
            "mstch_rust:cratemap=/Users/rcollins/github/sl/3rd-party/3rd-attempt/sapling/eden/scm/build/cargo-target/release/build/fb303_core-9691648f7f394b1c/out/cratemap,types_crate=fb303_core__types,clients_crate=fb303_core__clients,deprecated_default_enum_min_i32,serde",
            "--out",
            "/Users/rcollins/github/sl/3rd-party/3rd-attempt/sapling/eden/scm/build/cargo-target/release/build/fb303_core-9691648f7f394b1c/out",
            "-I",
            ".",
            "fb303/thrift/fb303_core.thrift",
        ],
        cwd: Some(
            "../../..",
        ),
    }' failed! Stdout:
  
    Stderr:
    [ERROR:fb303/thrift/fb303_core.thrift:30] Could not find include file thrift/annotation/cpp.thrift  ```